### PR TITLE
Robustify AMT

### DIFF
--- a/amt.go
+++ b/amt.go
@@ -25,7 +25,7 @@ const (
 // MaxIndex is the maximum index for elements in the AMT. This is currently 1^63
 // (max int) because the width is 8. That means every "level" consumes 3 bits
 // from the index, and 63/3 is a nice even 21
-const MaxIndex = uint64(1 << maxIndexBits)
+const MaxIndex = uint64(1<<maxIndexBits) - 1
 
 type Root struct {
 	Height uint64
@@ -66,7 +66,7 @@ func LoadAMT(ctx context.Context, bs cbor.IpldStore, c cid.Cid) (*Root, error) {
 }
 
 func (r *Root) Set(ctx context.Context, i uint64, val interface{}) error {
-	if i >= MaxIndex {
+	if i > MaxIndex {
 		return fmt.Errorf("index %d is out of range for the amt", i)
 	}
 
@@ -136,7 +136,7 @@ func (r *Root) BatchSet(ctx context.Context, vals []cbg.CBORMarshaler) error {
 }
 
 func (r *Root) Get(ctx context.Context, i uint64, out interface{}) error {
-	if i >= MaxIndex {
+	if i > MaxIndex {
 		return fmt.Errorf("index %d is out of range for the amt", i)
 	}
 
@@ -184,7 +184,7 @@ func (r *Root) BatchDelete(ctx context.Context, indices []uint64) error {
 }
 
 func (r *Root) Delete(ctx context.Context, i uint64) error {
-	if i >= MaxIndex {
+	if i > MaxIndex {
 		return fmt.Errorf("index %d is out of range for the amt", i)
 	}
 	//fmt.Printf("i: %d, h: %d, nfh: %d\n", i, r.Height, nodesForHeight(int(r.Height)))

--- a/amt_test.go
+++ b/amt_test.go
@@ -71,12 +71,12 @@ func TestOutOfRange(t *testing.T) {
 		t.Fatal("should have failed to set value out of range")
 	}
 
-	err = a.Set(ctx, MaxIndex, "what is up")
+	err = a.Set(ctx, MaxIndex+1, "what is up")
 	if err == nil {
 		t.Fatal("should have failed to set value out of range")
 	}
 
-	err = a.Set(ctx, MaxIndex-1, "what is up")
+	err = a.Set(ctx, MaxIndex, "what is up")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/amt_test.go
+++ b/amt_test.go
@@ -66,7 +66,7 @@ func TestOutOfRange(t *testing.T) {
 
 	a := NewAMT(bs)
 
-	err := a.Set(ctx, 1<<50, "what is up")
+	err := a.Set(ctx, 1<<63+4, "what is up")
 	if err == nil {
 		t.Fatal("should have failed to set value out of range")
 	}
@@ -79,6 +79,9 @@ func TestOutOfRange(t *testing.T) {
 	err = a.Set(ctx, MaxIndex-1, "what is up")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if a.Height != maxHeight {
+		t.Fatal("expected to be at the maximum height")
 	}
 }
 


### PR DESCRIPTION
* Remove floats and `math.Pow`.
* Set and enforce a maximum height.
* Set the max index to `2^63-1` (see the code for the reasoning).

We still need to do things like (future work):

* Enforce a maximum count.
* Fail if the tree is deeper than it should be.