### PR TITLE
avoid altering amt when empty

### DIFF
--- a/amt.go
+++ b/amt.go
@@ -492,17 +492,17 @@ func (n *Node) empty() bool {
 
 func (n *Node) Flush(ctx context.Context, bs cbor.IpldStore, depth int) error {
 	if depth == 0 {
+		if n.Bmap == nil {
+			n.Bmap = []byte{0}
+		}
+
 		if len(n.expVals) == 0 {
 			return nil
 		}
-		n.Bmap = nil
 		n.Values = nil
 		for i := uint64(0); i < width; i++ {
 			v := n.expVals[i]
 			if v != nil {
-				if n.Bmap == nil {
-					n.Bmap = []byte{0}
-				}
 				n.Values = append(n.Values, v)
 				n.setBit(i)
 			}

--- a/amt.go
+++ b/amt.go
@@ -19,6 +19,7 @@ const (
 	maxIndexBits = 63
 	widthBits    = 3
 	width        = 1 << widthBits             // 8
+	bitfieldSize = 1                          // ((width - 1) >> 3) + 1
 	maxHeight    = maxIndexBits/widthBits - 1 // 20 (because the root is at height 0).
 )
 
@@ -36,7 +37,7 @@ type Root struct {
 }
 
 type Node struct {
-	Bmap   []byte
+	Bmap   [bitfieldSize]byte
 	Links  []cid.Cid
 	Values []*cbg.Deferred
 
@@ -97,7 +98,7 @@ func (r *Root) Set(ctx context.Context, i uint64, val interface{}) error {
 			}
 
 			r.Node = Node{
-				Bmap:  []byte{0x01},
+				Bmap:  [...]byte{0x01},
 				Links: []cid.Cid{c},
 			}
 		}
@@ -406,7 +407,7 @@ func (n *Node) setBit(i uint64) {
 	}
 
 	if len(n.Bmap) == 0 {
-		n.Bmap = []byte{0}
+		n.Bmap = [...]byte{0}
 	}
 
 	n.Bmap[0] = n.Bmap[0] | byte(1<<i)
@@ -492,10 +493,6 @@ func (n *Node) empty() bool {
 
 func (n *Node) Flush(ctx context.Context, bs cbor.IpldStore, depth int) error {
 	if depth == 0 {
-		if n.Bmap == nil {
-			n.Bmap = []byte{0}
-		}
-
 		if len(n.expVals) == 0 {
 			return nil
 		}
@@ -515,7 +512,7 @@ func (n *Node) Flush(ctx context.Context, bs cbor.IpldStore, depth int) error {
 		return nil
 	}
 
-	n.Bmap = []byte{0}
+	n.Bmap = [...]byte{0}
 	n.Links = nil
 
 	for i := uint64(0); i < width; i++ {

--- a/amt.go
+++ b/amt.go
@@ -495,11 +495,14 @@ func (n *Node) Flush(ctx context.Context, bs cbor.IpldStore, depth int) error {
 		if len(n.expVals) == 0 {
 			return nil
 		}
-		n.Bmap = []byte{0}
+		n.Bmap = nil
 		n.Values = nil
 		for i := uint64(0); i < width; i++ {
 			v := n.expVals[i]
 			if v != nil {
+				if n.Bmap == nil {
+					n.Bmap = []byte{0}
+				}
 				n.Values = append(n.Values, v)
 				n.setBit(i)
 			}

--- a/amt_test.go
+++ b/amt_test.go
@@ -3,6 +3,7 @@ package amt
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
 	"time"
@@ -694,5 +695,30 @@ func TestFirstSetIndex(t *testing.T) {
 			t.Fatal("got wrong index out after serialization")
 		}
 	}
+}
 
+func TestEmptyCIDStability(t *testing.T) {
+	bs := cbor.NewCborStore(newMockBlocks())
+	ctx := context.Background()
+	a := NewAMT(bs)
+
+	c1, err := a.Flush(ctx)
+	require.NoError(t, err)
+
+	// iterating array should not affect its cid
+	a.ForEach(ctx, func(k uint64, val *cbg.Deferred) error {
+		return nil
+	})
+
+	c2, err := a.Flush(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, c1, c2)
+
+	// adding and removing and item should not affect its cid
+	a.Set(ctx, 0, "")
+	a.Delete(ctx, 0)
+
+	c3, err := a.Flush(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, c1, c3)
 }

--- a/cbor_gen.go
+++ b/cbor_gen.go
@@ -116,7 +116,7 @@ func (t *Node) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	// t.Bmap ([]uint8) (slice)
+	// t.Bmap ([1]uint8) (array)
 	if len(t.Bmap) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.Bmap was too long")
 	}
@@ -125,7 +125,7 @@ func (t *Node) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if _, err := w.Write(t.Bmap); err != nil {
+	if _, err := w.Write(t.Bmap[:]); err != nil {
 		return err
 	}
 
@@ -177,7 +177,7 @@ func (t *Node) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Bmap ([]uint8) (slice)
+	// t.Bmap ([1]uint8) (array)
 
 	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 	if err != nil {
@@ -190,8 +190,14 @@ func (t *Node) UnmarshalCBOR(r io.Reader) error {
 	if maj != cbg.MajByteString {
 		return fmt.Errorf("expected byte array")
 	}
-	t.Bmap = make([]byte, extra)
-	if _, err := io.ReadFull(br, t.Bmap); err != nil {
+
+	if extra != 1 {
+		return fmt.Errorf("expected array to have 1 elements")
+	}
+
+	t.Bmap = [1]uint8{}
+
+	if _, err := io.ReadFull(br, t.Bmap[:]); err != nil {
 		return err
 	}
 	// t.Links ([]cid.Cid) (slice)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/stretchr/testify v1.6.1
-	github.com/whyrusleeping/cbor-gen v0.0.0-20200710004633-5379fc63235d
+	github.com/whyrusleeping/cbor-gen v0.0.0-20200715143311-227fab5a2377
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158/go.mod h1:Xj/M2wWU+QdTdRbu/L/1dIZY8/Wb2K9pAhtroQuxJJI=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200710004633-5379fc63235d h1:wSxKhvbN7kUoP0sfRS+w2tWr45qlU8409i94hHLOT8w=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200710004633-5379fc63235d/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20200715143311-227fab5a2377 h1:LHFlP/ktDvOnCap7PsT87cs7Gwd0p+qv6Qm5g2ZPR+I=
+github.com/whyrusleeping/cbor-gen v0.0.0-20200715143311-227fab5a2377/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=


### PR DESCRIPTION
closes #18

### Motivation

Actions like calling `ForEach` or adding and removing elements put an empty AMT into a state that causes it to be serialized differently even though it is still the empty array. This is because these actions cause `expVals` to be expanded in the node from a nil value to a slice with nil values. While `expVals` isn't itself serialized, The fact that it is non-nil causes the node's `Bmap` value to be initialized from a nil value to `[]byte{0}` in `Flush`, and that does serialize differently.

### Proposed Changes

1. Add a test to demonstrate the problem.
2. Initialize `Node.Bmap` lazily in `Flush`.

This is probably the simplest solution that fixes the problem. It leaves open a bigger question about whether empty nodes should be structurally different when serialized from nodes containing one or more elements. I find it a little surprising, but not really wrong.