### PR TITLE
fix: reset leaf node bitmap on flush

### DIFF
--- a/amt.go
+++ b/amt.go
@@ -500,6 +500,7 @@ func (n *Node) Flush(ctx context.Context, bs cbor.IpldStore, depth int) error {
 		if len(n.expVals) == 0 {
 			return nil
 		}
+	  n.Bmap = [...]byte{0}
 		n.Values = nil
 		for i := uint64(0); i < width; i++ {
 			v := n.expVals[i]

--- a/amt.go
+++ b/amt.go
@@ -500,7 +500,7 @@ func (n *Node) Flush(ctx context.Context, bs cbor.IpldStore, depth int) error {
 		if len(n.expVals) == 0 {
 			return nil
 		}
-	  n.Bmap = [...]byte{0}
+		n.Bmap = [...]byte{0}
 		n.Values = nil
 		for i := uint64(0); i < width; i++ {
 			v := n.expVals[i]

--- a/amt_test.go
+++ b/amt_test.go
@@ -3,7 +3,6 @@ package amt
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
 	"time"


### PR DESCRIPTION
`Flush()` rebuilds the serializable form of the node and, setting the `Values` array for leaves and `Links` for non-leaves, in the process it sets up the bitmap again for each set element. On the non-leaf nodes we get a fresh bitmap to work with but the same is not done on leaf nodes.

I'm not convinced this is strictly necessary since `setBit()` and `clearBit()` are called on mutations elsewhere, but as long as we're doing a fresh rebuild and it's being done for non-leaf nodes, this should be done here to be absolutely sure, otherwise the `n.setBit(i)` isn't necessary either.