### PR TITLE
collapse the height of empty AMTs

### DIFF
--- a/amt.go
+++ b/amt.go
@@ -198,6 +198,7 @@ func (r *Root) Delete(ctx context.Context, i uint64) error {
 	}
 	r.Count--
 
+	// While we only have elements in left branch, collapse.
 	for r.Node.Bmap[0] == 1 && r.Height > 0 {
 		sub, err := r.Node.loadNode(ctx, r.store, 0, false)
 		if err != nil {
@@ -206,6 +207,11 @@ func (r *Root) Delete(ctx context.Context, i uint64) error {
 
 		r.Node = *sub
 		r.Height--
+	}
+	// If we have no elements, reset everything.
+	if r.Node.Bmap[0] == 0 {
+		r.Height = 0
+		r.Node = Node{} // to be safe.
 	}
 
 	return nil

--- a/amt_test.go
+++ b/amt_test.go
@@ -761,3 +761,20 @@ func TestEmptyCIDStability(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, c1, c3)
 }
+
+func TestRoundTrip(t *testing.T) {
+	bs := cbor.NewCborStore(newMockBlocks())
+	ctx := context.Background()
+	a := NewAMT(bs)
+	emptyCid, err := a.Flush(ctx)
+	require.NoError(t, err)
+
+	k := uint64(100000)
+	assertSet(t, a, k, "foo")
+	assertDelete(t, a, k)
+
+	c, err := a.Flush(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, emptyCid, c)
+}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -3,7 +3,7 @@ package main
 import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 
-	"github.com/filecoin-project/go-amt-ipld/v2"
+	"github.com/filecoin-project/go-amt-ipld/v3"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/filecoin-project/go-amt-ipld/v2
+module github.com/filecoin-project/go-amt-ipld/v3
 
 go 1.12
 


### PR DESCRIPTION
Currently, when we empty an AMT, we wouldn't collapse the height. This change fixes that.