### PR TITLE
Replace ErrNotFound with boolean return value

### DIFF
--- a/invalid_test.go
+++ b/invalid_test.go
@@ -53,6 +53,7 @@ func TestInvalidHeightTall(t *testing.T) {
 	require.NoError(t, err)
 
 	var out CborByteArray
-	err = after.Get(ctx, 31, &out)
-	require.Error(t, err)
+	found, err := after.Get(ctx, 31, &out)
+	require.NoError(t, err)
+	require.False(t, found)
 }

--- a/node.go
+++ b/node.go
@@ -193,10 +193,12 @@ func (n *node) get(ctx context.Context, bs cbor.IpldStore, bitWidth uint, height
 	// formed
 	if height == 0 {
 		d := n.getValue(i)
-		if d == nil {
-			return false, nil
+		found := d != nil
+		var err error
+		if found && out != nil {
+			err = out.UnmarshalCBOR(bytes.NewReader(d.Raw))
 		}
-		return true, out.UnmarshalCBOR(bytes.NewReader(d.Raw))
+		return found, err
 	}
 
 	// Non-leaf case where we need to navigate further down toward the correct


### PR DESCRIPTION
Removes ErrNotFound and replaces its use with an additional boolean return value from Get, Delete, BatchDelete and Subtract.

Depending on your view of whether ErrNotFound is a true error, this changes the semantics of Delete to make it not an "error" to attempt to delete a missing key.

This definitely changes the semantics of, BatchDelete and Subtract, which can now successfully delete only some of the keys requested. Subtract is unused in Filecoin actors, but BatchDelete is used quite a bit in the expiration and partition queues (rescheduling expirations, popping as queues). I've picked an easy (for the AMT) option of allowing keys to not exist. This would reduce the implicit consistency checking that the prior BatchDelete semantics offered. Callers would need to explicitly do something compare expected `Count` to check if all expected keys were actually deleted.

We have a few options here, and I'm keen for discussion
- Return boolean `modified`, true if any keys were found/removed (currently implemented)
- Return true if _all_ requested keys were found and removed
- Return a count of keys found and removed
- Return a slice of the keys found and removed
- Add a parameter indicating whether to expect all keys to exist, either considering a missing key an error, or changing the semantics of the boolean return value (any vs all).