### PR TITLE
fix: skip traversal of links with the same cid

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -263,6 +263,9 @@ func diffNode(ctx context.Context, prevCtx, curCtx *nodeContext, prev, cur *node
 		}
 
 		// Both previous and current have links to diff
+		if prev.links[i].cid == cur.links[i].cid {
+			continue
+		}
 
 		prevSubCtx := &nodeContext{
 			bs:       prevCtx.bs,

--- a/diff_parallel.go
+++ b/diff_parallel.go
@@ -414,6 +414,9 @@ func (s *diffScheduler) work(ctx context.Context, todo *task, results chan *Chan
 		}
 
 		// Both previous and current have links to diff
+		if prev.links[i].cid == cur.links[i].cid {
+			continue
+		}
 
 		prevSubCtx := &nodeContext{
 			bs:       prevCtx.bs,


### PR DESCRIPTION
Load tested with AMT that has 1M values and random 10 changes to mimic chain state changes. 
Here's some stats:
- bitwidth=3: `1075ms -> 0.7ms`
- bitwidth=4: `900ms -> 0.5ms`
- bitwidth=5: `757ms -> 1.5 ms`
- bitwidth=6: `638ms -> 0.6ms`
- bitwidth=7: `996ms -> 1ms`