### PR TITLE
chore: remove dependabot groups for updatability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,3 @@ updates:
       - "/fuzz/"
     schedule:
       interval: "monthly"
-    groups:
-      shared-dependencies:
-        group-by: "dependency-name"


### PR DESCRIPTION
Ran into this and it's annoying: https://github.com/dependabot/dependabot-core/issues/14780